### PR TITLE
Update esprima and estraverse deps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test": "grunt"
   },
   "dependencies": {
-    "esprima": "^1.2.2",
-    "estraverse": "^1.7.1"
+    "esprima": "^2.7.0",
+    "estraverse": "^4.1.1"
   }
 }


### PR DESCRIPTION
Without this the package is unable to generate templates for many ES6 features, specifically the module system.

```js
#!/usr/bin/env node

var fs = require('fs');
var estemplate = require('estemplate');
var escodegen = require('escodegen');

var template = estemplate.compile('export default <%= value %>;', {sourceType: 'module'});

var ast = template({
    value: {
        type: 'Literal',
        value: 'test'
    }
});

var output = escodegen.generate(ast);
console.log('it worked: ', output);
```

Without updating Esprima or Estraverse:

```
$ node index.js
/Users/kjones/code/js/codegen/node_modules/estemplate/node_modules/esprima/esprima.js:3734
            throw e;
            ^

Error: Line 1: Unexpected reserved word
    at throwError (/Users/kjones/code/js/codegen/node_modules/estemplate/node_modules/esprima/esprima.js:1846:21)
```

Only updating Esprima:

```
$ node index.js
/Users/kjones/code/js/codegen/node_modules/estemplate/node_modules/estraverse/estraverse.js:671
                    throw new Error('Unknown node type ' + nodeType + '.');
                    ^

Error: Unknown node type ExportDefaultDeclaration.
    at Controller.replace (/Users/kjones/code/js/codegen/node_modules/estemplate/node_modules/estraverse/estraverse.js:671:27)
```

With both updated:

```
$ node index.js
it worked:  export default 'test';
```