### PR TITLE
Upgrade estraverse

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   ],
   "devDependencies": {
     "escodegen": "^1.3.3",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-nodeunit": "^0.3.3",
     "grunt-contrib-watch": "^0.6.1",
@@ -42,6 +43,6 @@
   },
   "dependencies": {
     "esprima": "^1.2.2",
-    "estraverse": "^1.7.1"
+    "estraverse": "^4.1.1"
   }
 }


### PR DESCRIPTION
I don't have grunt globally (and don't want to have) so I added it in dep. estraverse is upgraded without problems. I'll try to upgrade esprima in the next PR.